### PR TITLE
Pass --qos to computeresources in pytme runner

### DIFF
--- a/scripts/pytme_runner.py
+++ b/scripts/pytme_runner.py
@@ -2,6 +2,7 @@
 """
 PyTME Batch Runner - Refactored Core Classes
 """
+
 import re
 import argparse
 import subprocess
@@ -1295,6 +1296,7 @@ def main():
         memory_gb=args.memory,
         time_limit=args.time_limit,
         partition=args.partition,
+        qos=args.qos,
         gpu_count=getattr(args, "gpu_count", 0),
         gpu_type=getattr(args, "gpu_type", None),
     )


### PR DESCRIPTION
Hello! I noticed that the --qos flag wasn't getting passed to the generated slurm scripts using pytme_runner matching because it was missing from the script. 
After adding it to the constructor call, it now shows up in the slurm script. (The extra newline is just black formatting).