### PR TITLE
Replace `ssize_t` with `py::ssize_t` for windows compatibility

### DIFF
--- a/tme/external/bindings.cpp
+++ b/tme/external/bindings.cpp
@@ -161,11 +161,11 @@ py::dict max_index_by_label(
     const U* labels_ptr = labels.data();
     const T* scores_ptr = scores.data();
 
-    std::unordered_map<U, std::pair<T, ssize_t>> max_scores;
+    std::unordered_map<U, std::pair<T, py::ssize_t>> max_scores;
 
     U label;
     T score;
-    for (ssize_t i = 0; i < labels.size(); ++i) {
+    for (py::ssize_t i = 0; i < labels.size(); ++i) {
         label = labels_ptr[i];
         score = scores_ptr[i];
 


### PR DESCRIPTION
Hi!

Disclaimer: the Windows-specific build issue and the proposed fix were initially identified with the assistance of an LLM. I validated the issue locally and confirmed that the change resolves the compilation failure on my system.

## Summary

This PR enables `pyTME` to compile on Windows using MSVC by replacing the non-portable `ssize_t` type with `py::ssize_t` in the pybind11 extension code.

Specifically, this fixes a Windows build failure caused by use of `ssize_t`, which is a POSIX-specific type and is not available in the default MSVC toolchain.

## Issue

On Windows (MSVC), the building of the package fails with:

```
error C2065: 'ssize_t': undeclared identifier
```

The root cause is that `ssize_t` is not part of standard C++, and unlike Linux/macOS toolchains, MSVC does not provide it by default.

Since this code is part of a pybind11 extension, `py::ssize_t` is a better fit:

- it maps to Python’s `Py_ssize_t`
- it is cross-platform
- it is intended for Python-compatible indexing and size handling

## Validation

With this change, I am able to successfully build `pyTME` using MSVC on Windows!

## Notes on tests

It would be good to test this PR on a Linux/macOS machine as most of the tests for me are passing, but not all. The tests that don't seem to be passing, seem I/O related. These failures seem to stem from temporary files being removed while still open, for example:

```python
_, self.path = mkstemp()
...
remove(self.path)
```

On Unix-like systems this is generally allowed, but on Windows an open file cannot be deleted, which results in errors such as:

```
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process
```

The file handles on Windows should first be closed before the file is allowed to be removed. However, I did not modify the tests, as that seems outside the scope of this PR.