### PR TITLE
Fix coordinates-to-coordinates score() passing kwargs __call__ rejects

### DIFF
--- a/tme/matching_optimization.py
+++ b/tme/matching_optimization.py
@@ -425,10 +425,7 @@ class _MatchCoordinatesToCoordinates(_MatchDensityToDensity):
             use_geometric_center=False,
         )
 
-        return self(
-            transformed_coordinates=self.template_coordinates_rotated,
-            transformed_coordinates_mask=self.template_mask_coordinates_rotated,
-        )
+        return self()
 
 
 class FLC(_MatchDensityToDensity):


### PR DESCRIPTION
### Problem

`optimize_match` on any coordinates-to-coordinates score (`Chamfer`, `NormalVectorScore`) raises:

```
TypeError: __call__() got an unexpected keyword argument 'transformed_coordinates'
```

`_MatchCoordinatesToCoordinates.score()` calls

```python
return self(
    transformed_coordinates=self.template_coordinates_rotated,
    transformed_coordinates_mask=self.template_mask_coordinates_rotated,
)
```

but the concrete `__call__` methods (`Chamfer`, `NormalVectorScore`) take **no** arguments — they
read `self.template_coordinates_rotated`, which `_rigid_transform(..., out=self.template_coordinates_rotated)`
has already written. So the kwargs are spurious and break the call.

### Fix

Make the coordinates-to-coordinates `score()` call `self()` with no kwargs, matching the
coordinates-to-**density** base (`_MatchCoordinatesToDensity.score`, which does `return self()`).

### Effect

`Chamfer` now optimises through `optimize_match`. `NormalVectorScore` still needs equal-size
*pre-paired* point clouds (its `__call__` multiplies `template_coordinates_rotated * target_coordinates`
elementwise) — a separate issue, noted but not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)