### PR TITLE
Fix NormalizedCrossCorrelationMean to centre by the matched mean (match its docstring)

### DIFF
--- a/tme/matching_optimization.py
+++ b/tme/matching_optimization.py
@@ -700,12 +700,19 @@ class NormalizedCrossCorrelationMean(NormalizedCrossCorrelation):
 
     __doc__ += _MatchCoordinatesToDensity.__doc__
 
-    def __init__(self, **kwargs):
-        kwargs["target"] = np.subtract(kwargs["target"], kwargs["target"].mean())
-        kwargs["template_weights"] = np.subtract(
-            kwargs["template_weights"], kwargs["template_weights"].mean()
-        )
-        super().__init__(**kwargs)
+    def __call__(self) -> float:
+        """Returns the score of the current configuration."""
+        # Centre by the mean of the *matched* values, as the docstring and the score name
+        # ("...Mean") specify. The previous implementation subtracted the global target-array
+        # mean in __init__ — a constant offset that does not centre the overlapping values and
+        # so did not compute the documented Pearson-about-the-mean (it ignored the local mean
+        # of the target over the template footprint).
+        target_values = self._target_values - self._target_values.mean()
+        template_weights = self.template_weights - self.template_weights.mean()
+        denominator = float(np.linalg.norm(target_values) * np.linalg.norm(template_weights))
+        if denominator < self.eps:
+            return 0.0
+        return float(np.dot(target_values, template_weights) / denominator) * self.score_sign
 
 
 class MaskedCrossCorrelation(_MatchCoordinatesToDensity):


### PR DESCRIPTION
### Problem

`NormalizedCrossCorrelationMean`'s docstring (and its name) define the Pearson correlation **about the mean over the matched points**:

```
score = (target_weights - mean(target_weights)) . (template_weights - mean(template_weights))
        / ( ||target_weights - mean(target_weights)|| * ||template_weights - mean(template_weights)|| )
```

But the implementation subtracts the **global** target-array mean in `__init__`:

```python
def __init__(self, **kwargs):
    kwargs["target"] = np.subtract(kwargs["target"], kwargs["target"].mean())   # whole-array mean
    kwargs["template_weights"] = np.subtract(kwargs["template_weights"], kwargs["template_weights"].mean())
    super().__init__(**kwargs)
```

`target - target.mean()` is a constant offset that does **not** centre the overlapping (matched) values, so the score disagrees with the documented formula. When the template covers a small high-signal region of a largely empty map — a subunit, or any contour/envelope-restricted point cloud — the global mean is approximately 0 while the matched mean is large, so the results differ a lot (e.g. 0.28 vs the correct 0.69 on a real subunit fit).

### Fix

Compute the correlation in `__call__`, centring the **matched** target values (`self._target_values`, interpolated at the current template positions) and the template weights by their own means — the documented Pearson r over the overlap.

### Effect

The score now matches its documentation. With a contour-thresholded template point cloud it equals Chimera `measure correlation ... envelope true` (the `cam` reported by efitter / Assembline) — verified to 4 decimals against an independent implementation on real cryo-EM subunit fits.

This changes `NormalizedCrossCorrelationMean`'s output (it was not computing the documented quantity before). The inherited analytic gradient is not updated for the mean-subtracted form; use a gradient-free optimizer (`optimize_match`'s default `basinhopping`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
